### PR TITLE
Add !important to .mceClear image height declaration

### DIFF
--- a/mce/clear/css/clear.css
+++ b/mce/clear/css/clear.css
@@ -5,7 +5,7 @@
     padding: 0;
     display: block;
     width: 96%;
-    height: 16px;
+    height: 16px !important;
     background: transparent url(../images/clear-line.png ) repeat-y scroll center center;
     cursor: default;
     resize: none;


### PR DESCRIPTION
Some responsive design patterns utilize a height: auto declaration
in conjunction with width: 100% (or something else) for the img tag.
This ensures that such themes will not make the divider appear
taller than intended.
